### PR TITLE
SSRN.29 - Transition to deprecated AsyncStorage API of React Native

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -341,7 +341,7 @@ PODS:
   - RNCAsyncStorage (1.15.17):
     - React-Core
   - SocketRocket (0.6.0)
-  - sovran-react-native (0.2.5):
+  - sovran-react-native (0.2.8):
     - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -534,10 +534,10 @@ SPEC CHECKSUMS:
   ReactCommon: d98c6c96b567f9b3a15f9fd4cc302c1eda8e3cf2
   RNCAsyncStorage: 6bd5a7ba3dde1c3facba418aa273f449bdc5437a
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  sovran-react-native: cefac22db7a541bd83e47c02228f4e56acad0f5b
+  sovran-react-native: e4064b633fd8232055d003460d5816dff87ba8cc
   Yoga: 9b6696970c3289e8dea34b3eda93f23e61fb8121
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: a39bacfb5179e8a0b71448f5a0e3cdba927982c3
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
     "react-native": "*"
   },
   "dependencies": {
-    "@react-native-async-storage/async-storage": "^1.15.15",
     "ansi-regex": "5.0.1",
     "deepmerge": "^4.2.2",
     "shell-quote": "1.7.3"

--- a/src/__mocks__/@react-native-async-storage/async-storage.js
+++ b/src/__mocks__/@react-native-async-storage/async-storage.js
@@ -1,1 +1,0 @@
-export default from '@react-native-async-storage/async-storage/jest/async-storage-mock';

--- a/src/persistor/async-storage-persistor.ts
+++ b/src/persistor/async-storage-persistor.ts
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AsyncStorage } from 'react-native';
 import type { Persistor } from './persistor';
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,13 +1663,6 @@
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
 
-"@react-native-async-storage/async-storage@^1.15.15":
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.16.1.tgz#1dbaa9e0f9736e4ab8fc04c628bbb608fd80b068"
-  integrity sha512-aQ7ka+Ii1e/q+7AVFIZPt4kDeSH8b784wMDtz19Kf4A7hf+OgCHBlUQpOXsrv8XxhlBxu0hv4tfrDO15ChnV0Q==
-  dependencies:
-    merge-options "^3.0.4"
-
 "@react-native-community/cli-debugger-ui@^6.0.0-rc.0":
   version "6.0.0-rc.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-6.0.0-rc.0.tgz#774378626e4b70f5e1e2e54910472dcbaffa1536"
@@ -5404,11 +5397,6 @@ is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-obj@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
-  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
-
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -6585,13 +6573,6 @@ meow@^8.0.0:
     trim-newlines "^3.0.0"
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
-
-merge-options@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
-  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
-  dependencies:
-    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Summary
The gist of this PR is that it allows for removal of `@react-native-async-storage/async-storage` dependency. Currently `@reat-native-async-storage/async-storage` is always imported since `AsyncStoragePersistor` is the default fallback if no `config.persist.persistor` option is provided in `createStore` function call. So by importing `AsyncStorage` api from `react-native` instead, the `@react-native-async-storage/async-storage` dependency can be removed.

# Use Case
Gopuff's app uses MMKV for key/value storage. And the Consumer Platform Team required that we remove the `@react-native-async-storage/async-storage` dependency.

# Unit Tests
Did not have to update any unit tests since the same API contract is utilized. Did however remove the mock for `@react-native-async-storage/async-storage`.

# References
- Feature request: https://github.com/segmentio/sovran-react-native/issues/29

 