### PR TITLE
chore: release 0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/sovran-react-native",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A cross-platform state management system",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Bumps Kotlin version to `1.6.0` to resolve build exception in Expo builds