### PR TITLE
refactor: make async storage a peer dependency

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -341,7 +341,7 @@ PODS:
   - RNCAsyncStorage (1.15.17):
     - React-Core
   - SocketRocket (0.6.0)
-  - sovran-react-native (0.4.3):
+  - sovran-react-native (0.4.5):
     - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -534,7 +534,7 @@ SPEC CHECKSUMS:
   ReactCommon: d98c6c96b567f9b3a15f9fd4cc302c1eda8e3cf2
   RNCAsyncStorage: 6bd5a7ba3dde1c3facba418aa273f449bdc5437a
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  sovran-react-native: d9adc84c3666579aacd5d96e315e399cd52241ac
+  sovran-react-native: fd3dc8f1a4b14acdc4ad25fc6b4ac4f52a2a2a15
   Yoga: 9b6696970c3289e8dea34b3eda93f23e61fb8121
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package.json
+++ b/package.json
@@ -157,11 +157,16 @@
     }
   },
   "peerDependencies": {
+    "@react-native-async-storage/async-storage": "*",
     "react": "*",
     "react-native": "*"
   },
+  "peerDependenciesMeta": {
+    "@react-native-async-storage/async-storage": {
+      "optional": true
+    }
+  },
   "dependencies": {
-    "@react-native-async-storage/async-storage": "^1.15.15",
     "ansi-regex": "5.0.1",
     "deepmerge": "^4.2.2",
     "shell-quote": "1.7.3"

--- a/src/persistor/async-storage-persistor.ts
+++ b/src/persistor/async-storage-persistor.ts
@@ -1,5 +1,15 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Persistor } from './persistor';
+
+let AsyncStorage: {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+} | null;
+
+try {
+  AsyncStorage = require('@react-native-async-storage/async-storage');
+} catch (error) {
+  AsyncStorage = null;
+}
 
 /**
  * Persistor implementation using AsyncStorage
@@ -7,7 +17,7 @@ import type { Persistor } from './persistor';
 export const AsyncStoragePersistor: Persistor = {
   get: async <T>(key: string): Promise<T | undefined> => {
     try {
-      const persistedStateJSON = await AsyncStorage.getItem(key);
+      const persistedStateJSON = await AsyncStorage?.getItem?.(key);
       if (persistedStateJSON !== null && persistedStateJSON !== undefined) {
         return JSON.parse(persistedStateJSON);
       }
@@ -20,7 +30,7 @@ export const AsyncStoragePersistor: Persistor = {
 
   set: async <T>(key: string, state: T): Promise<void> => {
     try {
-      await AsyncStorage.setItem(key, JSON.stringify(state));
+      await AsyncStorage?.setItem?.(key, JSON.stringify(state));
     } catch (e) {
       console.error(e);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,13 +1663,6 @@
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
 
-"@react-native-async-storage/async-storage@^1.15.15":
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.16.1.tgz#1dbaa9e0f9736e4ab8fc04c628bbb608fd80b068"
-  integrity sha512-aQ7ka+Ii1e/q+7AVFIZPt4kDeSH8b784wMDtz19Kf4A7hf+OgCHBlUQpOXsrv8XxhlBxu0hv4tfrDO15ChnV0Q==
-  dependencies:
-    merge-options "^3.0.4"
-
 "@react-native-community/cli-debugger-ui@^6.0.0-rc.0":
   version "6.0.0-rc.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-6.0.0-rc.0.tgz#774378626e4b70f5e1e2e54910472dcbaffa1536"
@@ -5404,11 +5397,6 @@ is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-obj@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
-  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
-
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -6585,13 +6573,6 @@ meow@^8.0.0:
     trim-newlines "^3.0.0"
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
-
-merge-options@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
-  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
-  dependencies:
-    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Context:
In my project, we use `@segment/analytics-react-native` & `@segment/sovran-react-native` and we use `react-native-mmkv-storage` for key-value storage solution (including custom persistor for segment client). Recently we wanted to remove `@react-native-async-storage/async-storage` as it's not used in our codebase. However segment libraries declare it as a `dependency`, even though it should be optional as `@segment/analytics-react-native` has an option to create custom persistor that matches `Persistor` type from `@segment/sovran-react-native`.
If it's possible, then let's mark `@react-native-async-storage/async-storage` as optional peer dependency to not force users to download it when custom persistor is used.
I'll make follow-up PR for `@segment/analytics-react-native`

- `@react-native-async-storage/async-storage` is marked as optional peer dependency
- `@react-native-async-storage/async-storage` is optionally required (instead of being imported) in `src/persistor/async-storage-persistor.ts`