### PR TITLE
fix type export bug in index file

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,6 @@ if (Sovran) {
 } else {
   console.warn(LINKING_ERROR);
 }
-export { createStore, Store, Notify, Unsubscribe } from './store';
+export { createStore, type Store, type Notify, type Unsubscribe } from './store';
 export { registerBridgeStore } from './bridge';
 export * from './persistor';


### PR DESCRIPTION
I was getting the following issues when running the project as an external dependency
<img width="884" alt="Screenshot 2023-01-27 at 13 27 31" src="https://user-images.githubusercontent.com/45874461/215086981-20385a37-2bc8-4010-98d0-4ba7530a877d.png">

The issue came from not specifying in the export that `Store, Notify, Unsubscribe` were types, so then when it gets converted to JS, the export of those types were not getting removed.

Before
<img width="1043" alt="Screenshot 2023-01-27 at 13 28 39" src="https://user-images.githubusercontent.com/45874461/215087947-ff5b05f1-4f57-4e2a-9287-c4566b647c99.png">
After
<img width="1181" alt="Screenshot 2023-01-27 at 13 34 09" src="https://user-images.githubusercontent.com/45874461/215088250-b34a7e40-40f8-41f5-8554-a105817a7c23.png">


